### PR TITLE
fix: restore correct deploy by not ignoring dist at deploy time

### DIFF
--- a/.github/workflows/lint-build-and-deploy.yml
+++ b/.github/workflows/lint-build-and-deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - run: npm run build
         env:
           MAPBOX_TOKEN: ${{secrets.MAPBOX_TOKEN}}
-
+      - run: rm .gitignore
       - name: deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ node_modules
 pnpm-debug.log
 
 /dist
-!/dist/index.html


### PR DESCRIPTION
 @derhuerst sorry for the burden :( 

i'm not 100% sure but from what i see, it seems to be related to `dist` being ignored, thus not deployed
as the action use the gh-pages branch

see https://github.com/peaceiris/actions-gh-pages/issues/445